### PR TITLE
Auto-start live market collector to keep WebSocket feeds active

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,13 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { I18nProvider } from './i18n';
 import './styles.css';
+import { startLiveMarketCollector } from './components/services/liveMarketCollector';
+
+// Ensure all exchange WebSocket feeds stay connected even if no UI component
+// subscribes to live market updates. This eagerly boots the collector during
+// application start so spot/futures streams are always active in the
+// background.
+startLiveMarketCollector();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- start the live market collector during application bootstrap so exchange WebSocket feeds stay connected even without subscribers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4c1d6d454832caafe8345a082b3bd