### PR TITLE
Fix navigation labels to use desktop variants

### DIFF
--- a/src/components/layouts/PremiumLayout.tsx
+++ b/src/components/layouts/PremiumLayout.tsx
@@ -148,7 +148,7 @@ export const PremiumSidebar: React.FC<PremiumSidebarProps> = ({ isOpen, onClose,
                                         onClick={onClose}
                                     >
                                         <i className={`fas ${item.icon} w-5`}></i>
-                                        <span>{resolveExchangeNavLabel(t, item.key)}</span>
+                                        <span>{resolveExchangeNavLabel(t, item.key, { variant: 'sidebar' })}</span>
                                     </Link>
                                 </li>
                             );
@@ -158,7 +158,7 @@ export const PremiumSidebar: React.FC<PremiumSidebarProps> = ({ isOpen, onClose,
                             <li key={item.key}>
                                 <button type="button" className={`${baseClasses} ${inactiveClasses} cursor-not-allowed`} disabled>
                                     <i className={`fas ${item.icon} w-5`}></i>
-                                    <span>{resolveExchangeNavLabel(t, item.key)}</span>
+                                    <span>{resolveExchangeNavLabel(t, item.key, { variant: 'sidebar' })}</span>
                                 </button>
                             </li>
                         );

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -39,39 +39,54 @@ export const EXCHANGE_NAV_ITEMS: ExchangeNavItem[] = [
   { key: 'announcements', icon: 'fa-bell', path: '/announcements' },
 ];
 
-export const EXCHANGE_NAV_TRANSLATIONS: Record<ExchangeNavKey, { primary: string; fallback: string }> = {
+type ExchangeNavLabelVariant = 'sidebar' | 'mobile';
+
+const EXCHANGE_NAV_TRANSLATIONS: Record<ExchangeNavKey, Record<ExchangeNavLabelVariant, string>> = {
   price_comparison: {
-    primary: 'bottom_nav.price_comparison',
-    fallback: 'sidebar.price_comparison'
+    sidebar: 'sidebar.price_comparison',
+    mobile: 'bottom_nav.price_comparison'
   },
   funding_info: {
-    primary: 'bottom_nav.funding_info',
-    fallback: 'sidebar.funding_info'
+    sidebar: 'sidebar.funding_info',
+    mobile: 'bottom_nav.funding_info'
   },
   airdrop_info: {
-    primary: 'bottom_nav.airdrop_info',
-    fallback: 'sidebar.airdrop_info'
+    sidebar: 'sidebar.airdrop_info',
+    mobile: 'bottom_nav.airdrop_info'
   },
   tradingview_auto: {
-    primary: 'bottom_nav.tradingview_auto',
-    fallback: 'sidebar.tradingview_auto'
+    sidebar: 'sidebar.tradingview_auto',
+    mobile: 'bottom_nav.tradingview_auto'
   },
   listing_info: {
-    primary: 'bottom_nav.listing_info',
-    fallback: 'sidebar.listing_info'
+    sidebar: 'sidebar.listing_info',
+    mobile: 'bottom_nav.listing_info'
   },
   announcements: {
-    primary: 'bottom_nav.announcements',
-    fallback: 'sidebar.announcements'
+    sidebar: 'sidebar.announcements',
+    mobile: 'bottom_nav.announcements'
   }
 };
 
-export const resolveExchangeNavLabel = (t: TranslationFunction, key: ExchangeNavKey) => {
+type ResolveExchangeNavLabelOptions = {
+  variant?: ExchangeNavLabelVariant;
+};
+
+export const resolveExchangeNavLabel = (
+  t: TranslationFunction,
+  key: ExchangeNavKey,
+  options?: ResolveExchangeNavLabelOptions
+) => {
+  const variant: ExchangeNavLabelVariant = options?.variant ?? 'sidebar';
+  const fallbackVariant: ExchangeNavLabelVariant = variant === 'sidebar' ? 'mobile' : 'sidebar';
   const translationKeys = EXCHANGE_NAV_TRANSLATIONS[key];
-  return t(translationKeys.primary, {
-    defaultValue: t(translationKeys.fallback)
+
+  return t(translationKeys[variant], {
+    defaultValue: t(translationKeys[fallbackVariant])
   });
 };
+
+export type { ExchangeNavLabelVariant, ResolveExchangeNavLabelOptions };
 
 // 모든 거래소를 하나로 합친 리스트 (기준거래소용)
 export const ALL_EXCHANGES_FOR_COMPARISON = [

--- a/src/pages/FeaturePage.tsx
+++ b/src/pages/FeaturePage.tsx
@@ -19,7 +19,7 @@ const featureIcons: Record<FeatureKey, string> = {
 const FeaturePageTemplate: React.FC<FeaturePageTemplateProps> = ({ featureKey }) => {
     const { t } = useTranslation();
     const icon = featureIcons[featureKey];
-    const featureLabel = resolveExchangeNavLabel(t, featureKey);
+    const featureLabel = resolveExchangeNavLabel(t, featureKey, { variant: 'sidebar' });
     const highlightKeys = [0, 1, 2].map(index => `feature_pages.${featureKey}.points.${index}`);
 
     return (


### PR DESCRIPTION
## Summary
- ensure exchange navigation labels differentiate between sidebar and mobile variants
- update premium sidebar and feature pages to request the desktop-friendly labels explicitly

## Testing
- npm test -- --watchAll=false *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_b_68d800c73fcc832c9709e97c8d526816